### PR TITLE
storage: update to use go-cloud underneath

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,17 @@ f.Close()
 
 ## S3
 
-Not yet implemented!  Watch this space.
+S3 is the default implementation for AWS S3. This uses [aws-sdk-go/aws/session.NewSession](http://docs.aws.amazon.com/sdk-for-go/api/aws/session/#NewSession) for authentication.
+
+```go
+store := storage.S3{Bucket:"some-bucket"}
+f, err := store.Open(context.Background(), "file.json") // will fetch "s3://some-bucket/file.json
+if err != nil {
+	// ...
+}
+// ...
+f.Close()
+```
 
 ## Wrappers and Helpers
 

--- a/cloudstorage.go
+++ b/cloudstorage.go
@@ -41,11 +41,11 @@ func (c *CloudStorage) Open(ctx context.Context, path string) (*File, error) {
 		return nil, err
 	}
 
-	// XXX(@benhinchley): https://github.com/google/go-cloud/pull/240
 	return &File{
 		ReadCloser: f,
 		Name:       path,
 		Size:       f.Size(),
+		ModTime:    f.ModTime(),
 	}, nil
 }
 

--- a/s3.go
+++ b/s3.go
@@ -19,7 +19,7 @@ import (
 
 // S3 is an implementation of FS which uses AWS S3 as the underlying storage layer.
 type S3 struct {
-	Bucket string // bucket is the name of the bucket to use as the underlying storage.
+	Bucket string // Bucket is the name of the bucket to use as the underlying storage.
 }
 
 // Open implements FS.

--- a/s3.go
+++ b/s3.go
@@ -7,7 +7,6 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -110,16 +109,14 @@ func (s *S3) bucketHandles(ctx context.Context) (*blob.Bucket, *s3.S3, error) {
 		}
 	}
 
-	c := aws.NewConfig().
-		WithRegion(region).
-		WithCredentials(credentials.NewEnvCredentials())
+	c := aws.NewConfig().WithRegion(region)
 	sess = sess.Copy(c)
 
 	b, err := s3blob.OpenBucket(ctx, sess, s.Bucket)
 	if err != nil {
 		return nil, nil, fmt.Errorf("s3: could not open %q: %v", s.Bucket, err)
 	}
-	s3 := s3.New(sess, c)
+	s3c := s3.New(sess, c)
 
-	return b, s3, nil
+	return b, s3c, nil
 }

--- a/s3.go
+++ b/s3.go
@@ -5,29 +5,121 @@ import (
 	"io"
 
 	"golang.org/x/net/context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+
+	"github.com/google/go-cloud/blob"
+	"github.com/google/go-cloud/blob/s3blob"
 )
 
 // S3 is an implementation of FS which uses AWS S3 as the underlying storage layer.
 type S3 struct {
-	Bucket string // Bucket is the name of the bucket to use as the underlying storage.
+	Bucket string // bucket is the name of the bucket to use as the underlying storage.
 }
 
 // Open implements FS.
 func (s *S3) Open(ctx context.Context, path string) (*File, error) {
-	return nil, fmt.Errorf("Open not implemented for S3")
+	b, _, err := s.bucketHandles(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := b.NewReader(ctx, path)
+	if err != nil {
+		if blob.IsNotExist(err) {
+			return nil, &notExistError{
+				Path: path,
+			}
+		}
+		return nil, fmt.Errorf("s3: unable to fetch object: %v", err)
+	}
+
+	// XXX(@benhinchley): https://github.com/google/go-cloud/pull/240
+	return &File{
+		ReadCloser: f,
+		Name:       path,
+		Size:       f.Size(),
+	}, nil
 }
 
 // Create implements FS.
 func (s *S3) Create(ctx context.Context, path string) (io.WriteCloser, error) {
-	return nil, fmt.Errorf("Create not implemented for S3")
+	b, _, err := s.bucketHandles(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return b.NewWriter(ctx, path, nil)
 }
 
 // Delete implements FS.
 func (s *S3) Delete(ctx context.Context, path string) error {
-	return fmt.Errorf("Delete not implemented for S3")
+	b, _, err := s.bucketHandles(ctx)
+	if err != nil {
+		return err
+	}
+	return b.Delete(ctx, path)
 }
 
 // Walk implements FS.
 func (s *S3) Walk(ctx context.Context, path string, fn WalkFn) error {
-	return fmt.Errorf("Walk not implemented for S3")
+	_, s3c, err := s.bucketHandles(ctx)
+	if err != nil {
+		return err
+	}
+	errCh := make(chan error, 1)
+
+	err = s3c.ListObjectsPagesWithContext(ctx, &s3.ListObjectsInput{
+		Bucket: aws.String(s.Bucket),
+		Prefix: aws.String(path),
+	}, func(page *s3.ListObjectsOutput, last bool) bool {
+		for _, obj := range page.Contents {
+			if err := fn(*obj.Key); err != nil {
+				errCh <- err
+				return false
+			}
+		}
+		return last
+	})
+	if err != nil {
+		return fmt.Errorf("s3: unable to walk: %v", err)
+	}
+
+	close(errCh)
+	return <-errCh
+}
+
+const bucketRegionHint = endpoints.UsEast1RegionID
+
+func (s *S3) bucketHandles(ctx context.Context) (*blob.Bucket, *s3.S3, error) {
+	sess, err := session.NewSession()
+	if err != nil {
+		return nil, nil, fmt.Errorf("s3: unable to create session: %v", err)
+	}
+
+	// https://docs.aws.amazon.com/sdk-for-go/api/service/s3/s3manager/#GetBucketRegion
+	region := aws.StringValue(sess.Config.Region)
+	if len(region) == 0 {
+		region, err = s3manager.GetBucketRegion(ctx, sess, s.Bucket, bucketRegionHint)
+		if err != nil {
+			return nil, nil, fmt.Errorf("s3: unable to find bucket region: %v", err)
+		}
+	}
+
+	c := aws.NewConfig().
+		WithRegion(region).
+		WithCredentials(credentials.NewEnvCredentials())
+	sess = sess.Copy(c)
+
+	b, err := s3blob.OpenBucket(ctx, sess, s.Bucket)
+	if err != nil {
+		return nil, nil, fmt.Errorf("s3: could not open %q: %v", s.Bucket, err)
+	}
+	s3 := s3.New(sess, c)
+
+	return b, s3, nil
 }

--- a/s3.go
+++ b/s3.go
@@ -38,11 +38,11 @@ func (s *S3) Open(ctx context.Context, path string) (*File, error) {
 		return nil, fmt.Errorf("s3: unable to fetch object: %v", err)
 	}
 
-	// XXX(@benhinchley): https://github.com/google/go-cloud/pull/240
 	return &File{
 		ReadCloser: f,
 		Name:       path,
 		Size:       f.Size(),
+		ModTime:    f.ModTime(),
 	}, nil
 }
 
@@ -70,8 +70,8 @@ func (s *S3) Walk(ctx context.Context, path string, fn WalkFn) error {
 	if err != nil {
 		return err
 	}
-	errCh := make(chan error, 1)
 
+	errCh := make(chan error, 1)
 	err = s3c.ListObjectsPagesWithContext(ctx, &s3.ListObjectsInput{
 		Bucket: aws.String(s.Bucket),
 		Prefix: aws.String(path),

--- a/storage.go
+++ b/storage.go
@@ -65,14 +65,14 @@ type FS interface {
 // FSFromURL takes a file system path and returns a FSWalker
 // corresponding to a supported storage system (CloudStorage,
 // S3, or Local if no platform-specific prefix is used).
-func FSFromURL(ctx context.Context, path string) (FS, error) {
+func FSFromURL(path string) FS {
 	if strings.HasPrefix(path, "gs://") {
-		return newCloudStorage(ctx, strings.TrimPrefix(path, "gs://"))
+		return &CloudStorage{Bucket: strings.TrimPrefix(path, "gs://")}
 	}
 	if strings.HasPrefix(path, "s3://") {
-		return &S3{Bucket: strings.TrimPrefix(path, "s3://")}, nil
+		return &S3{Bucket: strings.TrimPrefix(path, "s3://")}
 	}
-	return Local(path), nil
+	return Local(path)
 }
 
 // Prefix creates a FS which wraps fs and prefixes all paths with prefix.

--- a/storage.go
+++ b/storage.go
@@ -65,14 +65,14 @@ type FS interface {
 // FSFromURL takes a file system path and returns a FSWalker
 // corresponding to a supported storage system (CloudStorage,
 // S3, or Local if no platform-specific prefix is used).
-func FSFromURL(path string) FS {
+func FSFromURL(ctx context.Context, path string) (FS, error) {
 	if strings.HasPrefix(path, "gs://") {
-		return &CloudStorage{Bucket: strings.TrimPrefix(path, "gs://")}
+		return newCloudStorage(ctx, strings.TrimPrefix(path, "gs://"))
 	}
 	if strings.HasPrefix(path, "s3://") {
-		return &S3{Bucket: strings.TrimPrefix(path, "s3://")}
+		return &S3{Bucket: strings.TrimPrefix(path, "s3://")}, nil
 	}
-	return Local(path)
+	return Local(path), nil
 }
 
 // Prefix creates a FS which wraps fs and prefixes all paths with prefix.


### PR DESCRIPTION
This updates storage to use go-cloud underneath where possible, without breaking the existing api