### PR TITLE
use github.com/sajari/storage instead of code.sajari.com/storage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ go:
 - 1.8
 - 1.9
 - tip
-go_import_path: code.sajari.com/storage
+go_import_path: github.com/sajari/storage
 notifications:
   email:
     - infra@sajari.com

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Storage
 
 [![Build Status](https://travis-ci.org/sajari/storage.svg?branch=master)](https://travis-ci.org/sajari/storage)
-[![GoDoc](https://godoc.org/code.sajari.com/storage?status.svg)](https://godoc.org/code.sajari.com/storage)
+[![GoDoc](https://godoc.org/github.com/sajari/storage?status.svg)](https://godoc.org/github.com/sajari/storage)
 
 storage is a Go package which abstracts file systems (local, in-memory, Google Cloud Storage, S3) into a few interfaces.  It includes convenience wrappers for simplifying common file system use cases such as caching, prefix isolation and more!
 
@@ -12,12 +12,12 @@ storage is a Go package which abstracts file systems (local, in-memory, Google C
 # Installation
 
 ```console
-$ go get code.sajari.com/storage
+$ go get github.com/sajari/storage
 ```
 
 # Usage
 
-For full documentation see: [http://godoc.org/code.sajari.com/storage/](http://godoc.org/code.sajari.com/storage/).
+For full documentation see: [http://godoc.org/github.com/sajari/storage/](http://godoc.org/github.com/sajari/storage/).
 
 All storage in this package follow two simple interfaces designed for using file systems.
 

--- a/mem_test.go
+++ b/mem_test.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"code.sajari.com/storage"
+	"github.com/sajari/storage"
 )
 
 func TestMemOpen(t *testing.T) {

--- a/storage.go
+++ b/storage.go
@@ -1,6 +1,6 @@
 // Package storage provides types and functionality for abstracting storage systems (Local, in memory, S3, Google Cloud
 // storage) into a common interface.
-package storage // import "code.sajari.com/storage"
+package storage // import "github.com/sajari/storage"
 
 import (
 	"fmt"


### PR DESCRIPTION
## Summary

- Update import paths from `code.sajari.com/storage` to `github.com/sajari/storage`
- Update `.travis.yml`, `README.md`, `mem_test.go`, and `storage.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This allows us to remove the `replace` directive in rankee and allow rankee to be installed from remote source.